### PR TITLE
broker monitor retry, pulsar client upgrade, stop ticker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 all: push
 
-TAG ?= 0.0.1
+TAG ?= 0.0.3
 PREFIX ?= datastax/pulsar-monitor
 
 container:

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/antonmedv/expr v1.8.8
-	github.com/apache/pulsar-client-go v0.3.0
+	github.com/apache/pulsar-client-go v0.3.1-0.20201216220559-c1875485e1ad
 	github.com/apache/pulsar-client-go/oauth2 v0.0.0-20201202064457-9fe66edefe0d // indirect
 	github.com/apex/log v1.9.0
 	github.com/danieljoos/wincred v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,11 @@ github.com/apache/pulsar-client-go v0.1.0 h1:2BFZztxtNgFyOzBc+5On84CX6aIZW5xwh7K
 github.com/apache/pulsar-client-go v0.1.0/go.mod h1:G+CQVHnh2EPfNEQXOuisIDAyPMiKnzz4Vim/kjtj4U4=
 github.com/apache/pulsar-client-go v0.3.0 h1:rNhJ/ENwoEfZPHHwUHNxPBTNqNQE2LQEm7DXu043giM=
 github.com/apache/pulsar-client-go v0.3.0/go.mod h1:9eSgOadVhCfb2DfWtS1SCYaYIMk9VDOZztr4u3FO8cQ=
+github.com/apache/pulsar-client-go v0.3.1-0.20201216220559-c1875485e1ad h1:dVSODcfG7/Po2gk8fi9c6btIzzN4A1b/By2puWOABDU=
+github.com/apache/pulsar-client-go v0.3.1-0.20201216220559-c1875485e1ad/go.mod h1:pTmScVVHRhbB8wh0J+m5ZzHI0Lyfe0TwfPEbYEh+JUw=
 github.com/apache/pulsar-client-go/oauth2 v0.0.0-20200715083626-b9f8c5cedefb h1:E1P0FudxDdj2RhbveZC9i3PwukLCA/4XQSkBS/dw6/I=
 github.com/apache/pulsar-client-go/oauth2 v0.0.0-20200715083626-b9f8c5cedefb/go.mod h1:0UtvvETGDdvXNDCHa8ZQpxl+w3HbdFtfYZvDHLgWGTY=
+github.com/apache/pulsar-client-go/oauth2 v0.0.0-20201120111947-b8bd55bc02bd/go.mod h1:0UtvvETGDdvXNDCHa8ZQpxl+w3HbdFtfYZvDHLgWGTY=
 github.com/apache/pulsar-client-go/oauth2 v0.0.0-20201202064457-9fe66edefe0d h1:UR3Z6MjELJKTt5ph1eK5mYbYwS+uzNIoKbcCdU7cnLY=
 github.com/apache/pulsar-client-go/oauth2 v0.0.0-20201202064457-9fe66edefe0d/go.mod h1:gnyVPrpIp2XhG07THJh3ce3693JLtTRZ/TzgyZcF+ns=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=

--- a/src/brokers/broker-stats.go
+++ b/src/brokers/broker-stats.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package brokers
 
@@ -270,7 +270,7 @@ func TestBrokers(urlPrefix, clusterName, token string) (int, error) {
 				break
 			}
 		}
-		statsLog.Infof("broker %s health monitor required %d topic stats test, failed %d test", brokerURL, count, failureCount)
+		statsLog.Infof("broker %s health monitor failed %d test out of total required %d topic stats test", brokerURL, failureCount, count)
 	}
 
 	statsLog.Infof("cluster %s has %d failed brokers out of total %d brokers", clusterName, failedBrokers, len(brokers))

--- a/src/cfg/broker-monitor.go
+++ b/src/cfg/broker-monitor.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package cfg
 
@@ -37,6 +37,11 @@ func EvaluateBrokers(prefixURL, token string) error {
 	brokerCfg := GetConfig().BrokersConfig
 	clusterName := util.AssignString(GetConfig().ClusterName, GetConfig().Name)
 	failedBrokers, err := brokers.TestBrokers(prefixURL, clusterName, token)
+	if err != nil || failedBrokers > 0 {
+		// retry since all test calls are http based
+		time.Sleep(200 * time.Millisecond)
+		failedBrokers, err = brokers.TestBrokers(prefixURL, clusterName, token)
+	}
 
 	if failedBrokers > 0 {
 		errMsg := fmt.Sprintf("cluster %s has %d unhealthy brokers, error message %v", name, failedBrokers, err)
@@ -70,6 +75,7 @@ func MonitorBrokers() error {
 	go func(restURL, jwt string, loopInterval time.Duration) {
 		log.Infof("start all brokers monitoring every %v...", loopInterval)
 		ticker := time.NewTicker(loopInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/src/cfg/cluster-monitor.go
+++ b/src/cfg/cluster-monitor.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package cfg
 
@@ -108,6 +108,7 @@ func MonitorK8sPulsarCluster() error {
 	go func(client *k8s.Client) {
 		log.Infof("start k8s cluster monitoring ...")
 		ticker := time.NewTicker(clusterMonInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ticker.C:

--- a/src/cfg/config.go
+++ b/src/cfg/config.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package cfg
 
@@ -255,6 +255,7 @@ type monitorFunc func()
 func RunInterval(fn monitorFunc, interval time.Duration) {
 	go func() {
 		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
 		fn()
 		for {
 			select {

--- a/src/cfg/metrics.go
+++ b/src/cfg/metrics.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package cfg
 
@@ -318,6 +318,7 @@ func PushToPrometheusProxyThread() {
 	log.Infof("push to prometheus proxy url %s %t", GetConfig().PrometheusConfig.PrometheusProxyURL, promCfg.ExposeMetrics)
 	go func(url, apikey string) {
 		ticker := time.NewTicker(10 * time.Second)
+		defer ticker.Stop()
 		PushToPrometheusProxy(url, apikey)
 		for {
 			select {
@@ -350,6 +351,7 @@ func BuildTenantsUsageThread() {
 	log.Infof("build tenants uages from %s", prefixURL)
 	go func(url, jwt, cluster string) {
 		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
 		usage := metering.NewTenantsUsage(url, jwt, cluster, tenantBytesOutAlertLimit)
 		usage.UpdateUsages()
 		errStr := usage.ReportHighUsageTenant()
@@ -361,6 +363,7 @@ func BuildTenantsUsageThread() {
 		go func() {
 			alertInterval := util.TimeDuration(GetConfig().TenantUsageConfig.AlertIntervalMinutes, 120, time.Minute)
 			usageAlertTicker := time.NewTicker(alertInterval)
+			defer usageAlertTicker.Stop()
 			select {
 			case <-usageAlertTicker.C:
 				errStr := usage.ReportHighUsageTenant()

--- a/src/cfg/pulsar-latency.go
+++ b/src/cfg/pulsar-latency.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package cfg
 
@@ -244,6 +244,7 @@ func TopicLatencyTestThread() {
 	for _, topic := range topics {
 		go func(t TopicCfg) {
 			ticker := time.NewTicker(util.TimeDuration(t.IntervalSeconds, 60, time.Second))
+			defer ticker.Stop()
 			TestTopicLatency(t)
 			for {
 				select {

--- a/src/cfg/website-monitor.go
+++ b/src/cfg/website-monitor.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package cfg
 
@@ -109,6 +109,7 @@ func MonitorSites() {
 		go func(s SiteCfg) {
 			interval := util.TimeDuration(s.IntervalSeconds, 120, time.Second)
 			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
 			mon(s)
 			for {
 				select {

--- a/src/cfg/websocket.go
+++ b/src/cfg/websocket.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package cfg
 
@@ -231,6 +231,7 @@ func WebSocketTopicLatencyTestThread() {
 		cfg.reconcileConfig()
 		go func(t WsConfig) {
 			ticker := time.NewTicker(util.TimeDuration(t.IntervalSeconds, 60, time.Second))
+			defer ticker.Stop()
 			TestWsLatency(t)
 			for {
 				select {

--- a/src/topic/partition-topics.go
+++ b/src/topic/partition-topics.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package topic
 
@@ -198,7 +198,7 @@ func (pt *PartitionTopics) TestPartitionTopic(client pulsar.Client) (time.Durati
 	}
 	defer func() {
 		producer.Close()
-		log.Infof("closeeee producer name %s against topic name %s", producer.Name(), producer.Topic())
+		log.Infof("close producer name %s against topic name %s", producer.Name(), producer.Topic())
 	}()
 
 	// producer sends multiple messages

--- a/src/util/datastruct_test.go
+++ b/src/util/datastruct_test.go
@@ -1,23 +1,23 @@
- //
- //  Copyright (c) 2020-2021 Datastax, Inc.
- //  
- //  Licensed to the Apache Software Foundation (ASF) under one
- //  or more contributor license agreements.  See the NOTICE file
- //  distributed with this work for additional information
- //  regarding copyright ownership.  The ASF licenses this file
- //  to you under the Apache License, Version 2.0 (the
- //  "License"); you may not use this file except in compliance
- //  with the License.  You may obtain a copy of the License at
- //  
- //     http://www.apache.org/licenses/LICENSE-2.0
- //  
- //  Unless required by applicable law or agreed to in writing,
- //  software distributed under the License is distributed on an
- //  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- //  KIND, either express or implied.  See the License for the
- //  specific language governing permissions and limitations
- //  under the License.
- //
+//
+//  Copyright (c) 2020-2021 Datastax, Inc.
+//
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+//
 
 package util
 
@@ -69,6 +69,7 @@ func TestSyncMap(t *testing.T) {
 	}
 
 	ticker := time.NewTicker(4 * time.Second)
+	defer ticker.Stop()
 	finalCount := 0
 	for finalCount != it {
 		select {


### PR DESCRIPTION
- Add retry logic when broker monitor test fails
- Upgrade Pulsar client lib to pick up lingering goroutine fix
- Stop Ticker